### PR TITLE
Media definition regenerate failovers

### DIFF
--- a/src/Config/MediaConfig.php
+++ b/src/Config/MediaConfig.php
@@ -148,10 +148,7 @@ final class MediaConfig
             /** @var Uri $projectUri */
             $projectUri = $this->projectUri;
 
-            $uri = $uri->withPath(\rtrim($projectUri->getMainUri()->getPath(), '/') . '/' . \ltrim(
-                $uri->getPath(),
-                '/'
-                ));
+            $uri = $uri->withPath(\rtrim($projectUri->getMainUri()->getPath(), '/') . '/' . \ltrim($uri->getPath(), '/'));
             $uri = $uri->withHost($projectUri->getMainUri()->getHost());
             $uri = $uri->withScheme($projectUri->getMainUri()->getScheme());
             $uri = $uri->withPort($projectUri->getMainUri()->getPort());
@@ -174,27 +171,27 @@ final class MediaConfig
         }
         // @codeCoverageIgnoreStart
         if (\in_array($this->driver, $allowedConfigParameter)) {
-            switch ($this->driver):
+            switch ($this->driver) {
                 case 'gd':
                     if (\extension_loaded('gd') === false) {
                         throw new InvalidExtensionException("PHP Extension 'gd' could not be found");
                     }
-            break;
-            case 'imagick':
+                    break;
+                case 'imagick':
                     if (\extension_loaded('imagick') === false) {
                         throw new InvalidExtensionException("PHP Extension 'imagick' could not be found");
                     }
-            break;
-            case 'automatic':
+                    break;
+                case 'automatic':
                     $this->driver = 'imagick';
-            if (\extension_loaded('imagick') === false) {
-                $this->driver = 'gd';
-                if (\extension_loaded('gd') === false) {
-                    throw new InvalidExtensionException("Neither 'gd' or 'imagick' PHP Extension could be found");
-                }
+                    if (\extension_loaded('imagick') === false) {
+                        $this->driver = 'gd';
+                        if (\extension_loaded('gd') === false) {
+                            throw new InvalidExtensionException("Neither 'gd' or 'imagick' PHP Extension could be found");
+                        }
+                    }
+                    break;
             }
-            break;
-            endswitch;
         } else {
             throw new InvalidConfigException(\sprintf("Given media config driver: '%s', is not valid", $this->driver));
         }

--- a/src/Console/RegenerateDefinitionCommand.php
+++ b/src/Console/RegenerateDefinitionCommand.php
@@ -162,7 +162,6 @@ final class RegenerateDefinitionCommand extends Command implements CommandInterf
         }
 
         if ($input->getArgument('name')) {
-
             if ($input->getOption('all') || $input->getOption('changed')) {
                 $style->error('regeneration of a specific ImageDefinition can not be combined with "--all" or "--changed"');
                 return 1;

--- a/src/Entity/Media.php
+++ b/src/Entity/Media.php
@@ -99,7 +99,7 @@ final class Media implements EntityInterface, DatabaseEntityInterface, MediaInte
         return $this->createdAt;
     }
 
-    public function updatedAt(): DateTimeType
+    public function updatedAt(): ?DateTimeType
     {
         return $this->updatedAt;
     }
@@ -122,7 +122,7 @@ final class Media implements EntityInterface, DatabaseEntityInterface, MediaInte
             new Definition('metaData', TypeInterface::TYPE_ARRAY, true, true),
             new Definition('createdBy', UuidType::class, true, true),
             new Definition('createdAt', DateTimeType::class, false, true),
-            new Definition('updatedAt', DateTimeType::class, false, true),
+            new Definition('updatedAt', DateTimeType::class, true, true),
             new Definition('deletedAt', DateTimeType::class, true, true),
         ]);
     }

--- a/src/Handler/ImageHandler.php
+++ b/src/Handler/ImageHandler.php
@@ -20,6 +20,7 @@ use Ixocreate\Media\MediaInterface;
 use Ixocreate\Media\Processor\ImageProcessor;
 use Ixocreate\Media\Repository\MediaDefinitionInfoRepository;
 use Ixocreate\Media\Repository\MediaRepository;
+use League\Flysystem\FileNotFoundException;
 
 final class ImageHandler implements MediaHandlerInterface
 {
@@ -259,7 +260,11 @@ final class ImageHandler implements MediaHandlerInterface
     {
         $file = $this->mediaPath . $this->media->basePath() . $this->media->filename();
 
-        $imageData = \getimagesizefromstring($filesystem->read($file));
+        try {
+            $imageData = \getimagesizefromstring($filesystem->read($file));
+        } catch (FileNotFoundException $exception) {
+            return;
+        }
 
         $metaData = [
             'width' => $imageData[0],

--- a/src/Handler/ImageHandler.php
+++ b/src/Handler/ImageHandler.php
@@ -178,7 +178,6 @@ final class ImageHandler implements MediaHandlerInterface
                         default:
                             $pids[$pid] = $pid;
                     }
-
                 }
 
                 foreach ($pids as $pid) {

--- a/src/Processor/ImageProcessor.php
+++ b/src/Processor/ImageProcessor.php
@@ -17,6 +17,7 @@ use Ixocreate\Media\Config\MediaConfig;
 use Ixocreate\Media\Config\MediaPaths;
 use Ixocreate\Media\ImageDefinition\ImageDefinitionInterface;
 use Ixocreate\Media\MediaInterface;
+use League\Flysystem\FileNotFoundException;
 
 final class ImageProcessor
 {
@@ -103,8 +104,12 @@ final class ImageProcessor
 
         $mediaPath = $this->media->publicStatus() ? MediaPaths::PUBLIC_PATH : MediaPaths::PRIVATE_PATH;
 
-        /** @var Image $image */
-        $image = ($this->image !== null) ? $this->image : $imageManager->make($this->filesystem->read($mediaPath . $this->media->basePath() . $this->media->filename()));
+        try {
+            /** @var Image $image */
+            $image = ($this->image !== null) ? $this->image : $imageManager->make($this->filesystem->read($mediaPath . $this->media->basePath() . $this->media->filename()));
+        } catch (FileNotFoundException $exception) {
+            return false;
+        }
 
         $this->imageParameters['imageWidth'] = $image->width();
         $this->imageParameters['imageHeight'] = $image->height();

--- a/src/Schema/Type/ImageType.php
+++ b/src/Schema/Type/ImageType.php
@@ -87,10 +87,7 @@ final class ImageType extends AbstractType implements DatabaseTypeInterface, Ele
         $type = clone $this;
         $mediaType = Type::create($value, MediaType::class);
 
-        if (!empty($mediaType->value()) && \in_array(
-            $mediaType->value()->mimeType(),
-            $this->mediaConfig->imageWhitelist()
-            )) {
+        if (!empty($mediaType->value()) && \in_array($mediaType->value()->mimeType(), $this->mediaConfig->imageWhitelist())) {
             $type->mediaType = $mediaType;
 
             $type->imageDefinitionInfos = (new Collection($this->mediaDefinitionInfoRepository


### PR DESCRIPTION
`ixocreate media:regenerate-definition --all` has to be run to allow editing existing media files in admin (cannot check valid size if metadata has not been updated for croppable media).

Yet, the command fails if:
- the db entry has no `updatedAt` timestamp (older entries)
- the file does not exist anymore (occured with an imported db where media files were not moved over)